### PR TITLE
Fix #102 and invalidate checkupdates cache after 5 minutes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,8 +65,14 @@ Templates create variant combinations using `-` separator:
 - Use Ruff for formatting/linting, basedpyright for type checking.
 - Type hints required on all function signatures and variables.
 - Import order: standard library → third-party → local imports.
-- Imports should not be merged, always have one import per line.
-- `import` lines should always come before `from X import Y` lines and be separated by a blank line
+- Imports should always be alphabetically sorted within it's group.
+- Imports should always be merged, but each thing being imported should be on it's own line followed by a comma. e.g.:
+  ```python
+  from typing import (
+    Callable,
+    cast,
+  )
+  ```
 - Package `from .X import Y` lines should always come after `from X import Y` lines and be separated by a blank line
 - Use `cast()` for type assertions when needed.
 - Every `make/*.py` command must have exactly `register()` and `command()` functions.

--- a/overlay/base/usr/lib/system/_os/cli/checkupdates.py
+++ b/overlay/base/usr/lib/system/_os/cli/checkupdates.py
@@ -1,15 +1,23 @@
 import sys
 import traceback
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
+from typing import (
+    Any,
+    cast,
+)
 
-from argparse import ArgumentParser
-from argparse import Namespace
-from typing import cast
-from typing import Any
-
-from ..dbus import checkupdates
-from ..dbus import pull
-from ..system import _execute  # pyright:ignore [reportPrivateUsage]
-from ..system import baseImage
+from ..dbus import (
+    checkupdates,
+    pull,
+    pull_available,
+)
+from ..system import (
+    _execute,  # pyright:ignore [reportPrivateUsage]
+    baseImage,
+)
 
 kwds = {"help": "Checks for updates to the system"}
 
@@ -33,9 +41,10 @@ def command(args: Namespace) -> None:
         print("Not currently online", file=sys.stderr)
         sys.exit(1)
 
+    force = cast(bool, args.force)
     updates: list[str] = []
     try:
-        updates = checkupdates(cast(bool, args.force))
+        updates = checkupdates(force)
 
     except BaseException:
         traceback.print_exc()
@@ -46,14 +55,17 @@ def command(args: Namespace) -> None:
 
     print("\n".join(updates))
     if cast(bool, args.download):
-        image = baseImage()
-        try:
-            if [x for x in updates if x.startswith(f"{image} ")]:
+        if (
+            [x for x in updates if x.startswith(f"{baseImage()} ")]
+            and force
+            or pull_available()
+        ):
+            try:
                 pull()
 
-        except BaseException:
-            traceback.print_exc()
-            sys.exit(1)
+            except BaseException:
+                traceback.print_exc()
+                sys.exit(1)
 
     sys.exit(2)
 

--- a/overlay/base/usr/lib/system/_os/daemon/system.py
+++ b/overlay/base/usr/lib/system/_os/daemon/system.py
@@ -1,27 +1,36 @@
-import dbus  # pyright:ignore [reportMissingTypeStubs]
-import dbus.service  # pyright:ignore [reportMissingTypeStubs]
 import os
 import subprocess
 import threading
+import time
 import traceback
-
-from typing import Callable
+from collections.abc import Callable
 from typing import cast
 
-from .. import SYSTEM_PATH
+import dbus  # pyright:ignore [reportMissingTypeStubs]
+import dbus.service  # pyright:ignore [reportMissingTypeStubs]
 
-from ..podman import build
-from ..podman import pull
-from ..system import baseImage
-from ..system import checkupdates
-from ..system import update_bootloader
-from ..system import system_kernelCommandLine
+from .. import SYSTEM_PATH
+from ..console import (
+    bytes_to_stderr,
+    bytes_to_stdout,
+)
 from ..dbus import groups_for_sender
-from ..console import bytes_to_stdout
-from ..console import bytes_to_stderr
-from ..ostree import commit_export
-from ..ostree import prune
-from ..ostree import deploy
+from ..ostree import (
+    commit_export,
+    deploy,
+    prune,
+)
+from ..podman import (
+    build,
+    image_digest,
+    pull,
+)
+from ..system import (
+    baseImage,
+    checkupdates,
+    system_kernelCommandLine,
+    update_bootloader,
+)
 
 
 class Object(dbus.service.Object):
@@ -31,6 +40,7 @@ class Object(dbus.service.Object):
             object_path="/system",
         )
         self._updates: list[str] = []
+        self._updates_ttl: float = time.time()
         self._notification: dict[str, str] = {}
         self._upgrade_status: str = ""
         self._build_status: str = ""
@@ -523,6 +533,7 @@ class Object(dbus.service.Object):
     def _checkupdates(self):
         try:
             self._updates = checkupdates()
+            self._updates_ttl = time.time() + 60 * 5  # recheck in 5 minutes
             if not self._updates:
                 self.checkupdates_status("none")
 
@@ -574,6 +585,9 @@ class Object(dbus.service.Object):
         out_signature="as",
     )
     def updates(self) -> list[str]:
+        if time.time() >= self._updates_ttl:
+            return []
+
         return self._updates
 
     @dbus.service.method(  # pyright:ignore [reportUnknownMemberType]
@@ -660,3 +674,12 @@ class Object(dbus.service.Object):
     )
     def pull_stderr(self, stderr: bytes):
         bytes_to_stderr(b"[pull:2] " + stderr)
+
+    @dbus.service.method(  # pyright:ignore [reportUnknownMemberType]
+        dbus_interface="system.pull",
+        in_signature="",
+        out_signature="b",
+    )
+    def pull_available(self) -> bool:
+        image = baseImage()
+        return image_digest(image, remote=False) != image_digest(image, remote=True)

--- a/overlay/base/usr/lib/system/_os/daemon/system.py
+++ b/overlay/base/usr/lib/system/_os/daemon/system.py
@@ -23,6 +23,7 @@ from ..ostree import (
 from ..podman import (
     build,
     image_digest,
+    image_exists,
     pull,
 )
 from ..system import (
@@ -682,4 +683,6 @@ class Object(dbus.service.Object):
     )
     def pull_available(self) -> bool:
         image = baseImage()
-        return image_digest(image, remote=False) != image_digest(image, remote=True)
+        return not image_exists(image, remote=False) or (
+            image_digest(image, remote=False) != image_digest(image, remote=True)
+        )

--- a/overlay/base/usr/lib/system/_os/dbus.py
+++ b/overlay/base/usr/lib/system/_os/dbus.py
@@ -1,13 +1,17 @@
-import dbus  # pyright:ignore [reportMissingTypeStubs]
-import dbus.service  # pyright:ignore [reportMissingTypeStubs]
 import grp
 import pwd
-
-from dbus.mainloop.glib import DBusGMainLoop  # pyright:ignore [reportMissingTypeStubs,reportUnknownVariableType]
-from gi.repository import GLib  # pyright:ignore [reportMissingTypeStubs,reportUnknownVariableType,reportAttributeAccessIssue]
-
-from typing import Callable
+from collections.abc import Callable
 from typing import cast
+
+import dbus  # pyright:ignore [reportMissingTypeStubs]
+import dbus.service  # pyright:ignore [reportMissingTypeStubs]
+from dbus.mainloop.glib import (  # pyright: ignore[reportMissingTypeStubs]
+    DBusGMainLoop,  # pyright:ignore [reportUnknownVariableType]
+)
+from gi.repository import (  # pyright: ignore[reportMissingTypeStubs]
+    GLib,  # pyright:ignore [reportUnknownVariableType,reportAttributeAccessIssue]
+)
+
 from .console import print_stderr
 
 
@@ -84,6 +88,19 @@ def pull(
     loop.run()  # pyright:ignore [reportUnknownMemberType]
     if getattr(on_status, "status") == "error":
         raise Exception("Base image pull failed")
+
+
+def pull_available() -> bool:
+    DBusGMainLoop(set_as_default=True)
+    bus = dbus.SystemBus()
+    interface = dbus.Interface(
+        bus.get_object(  # pyright:ignore [reportUnknownMemberType]
+            "os.system",
+            "/system",
+        ),
+        "system.pull",
+    )
+    return cast(Callable[[], bool], interface.pull_available)()
 
 
 def upgrade(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to detect whether a base image pull is available (exposed for CLI/DBus use).

* **Refactor**
  * Introduced short-lived caching for update results to reduce redundant checks and improve responsiveness.
  * Improved download decision logic to more accurately trigger pulls and correctly respect force behavior.

* **Documentation**
  * Relaxed and clarified Python import/style rules in AGENTS.md.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->